### PR TITLE
Update usb_intf.c

### DIFF
--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -208,6 +208,7 @@ static struct usb_device_id rtw_usb_id_tbl[] ={
 	{USB_DEVICE(0x2001, 0x331a), .driver_info = RTL8814A}, /* D-Link - D-Link */
 	{USB_DEVICE(0x0b05, 0x1817), .driver_info = RTL8814A}, /* ASUS - ASUSTeK */
 	{USB_DEVICE(0x0b05, 0x1852), .driver_info = RTL8814A}, /* ASUS - ASUSTeK */
+	{USB_DEVICE(0x0b05, 0x1853), .driver_info = RTL8814A}, /* ASUS - ASUSTeK */
 	{USB_DEVICE(0x056E, 0x400B), .driver_info = RTL8814A}, /* ELECOM - ELECOM */
 	{USB_DEVICE(0x056E, 0x400D), .driver_info = RTL8814A}, /* ELECOM - ELECOM */
 	{USB_DEVICE(0x7392, 0xA833), .driver_info = RTL8814A}, /* Edimax - Edimax */


### PR DESCRIPTION
Added support for new rev. Asus USB-AC68 Wireless-AC1900 USB.

```
$ lsusb
Bus 001 Device 004: ID 0b05:1853 ASUSTek Computer, Inc.
```

```$ dmesg
[  801.438487] cfg80211: Loading compiled-in X.509 certificates for regulatory database
[  801.440910] cfg80211: Loaded X.509 cert 'sforshee: ..'
[  801.440930] platform regulatory.0: Direct firmware load for regulatory.db failed with error -2
[  801.440932] cfg80211: failed to load regulatory.db
[  801.452749] RTL871X: module init start
[  801.452750] RTL871X: rtl8814au v4.3.21_17997.20160531
[  801.573567] RTL871X: rtw_ndev_init(wlan0) if1 mac_addr=...
[  801.574143] usbcore: registered new interface driver rtl8814au
[  801.574146] RTL871X: module init ret=0
[  801.579220] rtl8814au 1-3:1.0 wlp0s20f0u3: renamed from wlan0
[  801.588277] IPv6: ADDRCONF(NETDEV_UP): wlp0s20f0u3: link is not ready
[  801.980538] IPv6: ADDRCONF(NETDEV_UP): wlp0s20f0u3: link is not ready
[  801.983229] IPv6: ADDRCONF(NETDEV_UP): wlp0s20f0u3: link is not ready
[  802.009230] IPv6: ADDRCONF(NETDEV_UP): wlp0s20f0u3: link is not ready
[  805.774078] RTL871X: nolinked power save enter
[  822.432034] RTL871X: nolinked power save leave
[  826.262023] RTL871X: nolinked power save enter
[  852.642999] RTL871X: nolinked power save leave
[  856.397474] RTL871X: nolinked power save enter
[  867.651134] RTL871X: nolinked power save leave
[  871.421534] RTL871X: nolinked power save enter
[  879.683638] IPv6: ADDRCONF(NETDEV_UP): wlp0s20f0u3: link is not ready
[  888.513262] RTL871X: nolinked power save leave
[  892.317413] RTL871X: rtw_set_802_11_connect(wlp0s20f0u3)  fw_state=0x00000008
[  892.458237] RTL871X: start auth
[  892.460028] RTL871X: auth success, start assoc
[  892.462116] RTL871X: rtw_cfg80211_indicate_connect(wlp0s20f0u3) BSS not found !!
[  892.462119] RTL871X: assoc success
[  892.470011] RTL871X: recv eapol packet
[  892.470197] RTL871X: send eapol packet
[  892.479503] RTL871X: recv eapol packet
[  892.479794] RTL871X: send eapol packet
[  892.479959] RTL871X: set pairwise key camid:4, addr:.., kid:0, type:AES
[  892.480136] IPv6: ADDRCONF(NETDEV_CHANGE): wlp0s20f0u3: link becomes ready
[  892.481201] RTL871X: set group key camid:5, addr:..., kid:1, type:AES
```

Any other places I should add this ID?

Thanks!